### PR TITLE
Convert demo into test and add nested test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ serde = { version = "1.0.136", default-features = false, features = [
     "std",
     "derive",
 ] }
-anyhow = "1.0.56"
+pretty_assertions = "1.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,3 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod private;
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}

--- a/src/private.rs
+++ b/src/private.rs
@@ -5,8 +5,6 @@ bufferless deserialization
 
 pub mod flatten;
 
-use std::marker::PhantomData;
-
 use serde::{de, forward_to_deserialize_any};
 
 /// Struct to fuse a MapAccess or a SeqAccess
@@ -197,22 +195,25 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 pub struct ByteBufDeserializer<E> {
     buf: Vec<u8>,
-    phantom: PhantomData<E>,
+    phantom: std::marker::PhantomData<E>,
 }
 
+#[cfg(feature = "std")]
 impl<E> ByteBufDeserializer<E> {
     #[inline]
     #[must_use]
     pub fn new(buf: Vec<u8>) -> Self {
         Self {
             buf,
-            phantom: PhantomData,
+            phantom: std::marker::PhantomData,
         }
     }
 }
 
+#[cfg(feature = "std")]
 impl<'de, E> de::Deserializer<'de> for ByteBufDeserializer<E>
 where
     E: de::Error,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -109,10 +109,15 @@ impl<'de> Deserialize<'de> for Outer {
 fn one_field() {
     let data: Outer = serde_json::from_str(
         r#"{
+            "_1": 1,
             "integer": 10,
+            "_2": 2,
             "before": 10.5,
+            "_3": 3,
             "string": "hello",
-            "after": true
+            "_4": 4,
+            "after": true,
+            "_5": 5
         }"#,
     )
     .expect("failed to parse JSON");

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -104,6 +104,7 @@ impl<'de> Deserialize<'de> for Outer {
     }
 }
 
+#[test]
 fn main() -> anyhow::Result<()> {
     let data: Outer = serde_json::from_str(
         r#"{

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,8 +1,8 @@
-use anyhow::Context;
+use pretty_assertions::assert_eq;
 use serde::{de, Deserialize};
 use serde_bufferless::private::flatten::{FlattenDeserializer, KeyCapture};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, PartialEq, Deserialize)]
 struct Inner {
     integer: i32,
     string: String,
@@ -12,7 +12,7 @@ struct Inner {
     float: f32,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct Outer {
     float: f32,
     boolean: bool,
@@ -105,7 +105,7 @@ impl<'de> Deserialize<'de> for Outer {
 }
 
 #[test]
-fn main() -> anyhow::Result<()> {
+fn one_field() {
     let data: Outer = serde_json::from_str(
         r#"{
             "integer": 10,
@@ -114,9 +114,19 @@ fn main() -> anyhow::Result<()> {
             "boolean": true
         }"#,
     )
-    .context("failed to parse json")?;
+    .expect("failed to parse JSON");
 
-    println!("{:#?}", data);
+    assert_eq!(
+        data,
+        Outer {
+            float: 10.5,
+            boolean: true,
 
-    Ok(())
+            inner: Inner {
+                integer: 10,
+                string: "hello".to_string(),
+                float: 0.0,
+            },
+        }
+    );
 }


### PR DESCRIPTION
That is an interesting work! To better understand the limitations of the approach, I added a couple of tests. The first one (`one_field`) is transformed from your demo. The `nested` test shows that fields from the outer level always takes precedence over fields with the same name from flattened fields, do not matter if they defined before or after the flattened field.